### PR TITLE
CLEAN Fix so release-for-testing also works when for Pull request

### DIFF
--- a/.github/workflows/release-for-testing.yml
+++ b/.github/workflows/release-for-testing.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set env
         run: |
           set -ue ;
-          tag=$(echo ${GITHUB_REF#refs/heads/} | cut -c 1-20) ;
+          tag=$(echo ${GITHUB_REF_NAME} | cut -c 1-20) ;
           echo "VERSION=$(echo $tag)" >> $GITHUB_ENV ;
         shell: bash
 


### PR DESCRIPTION
Had [this workflow](https://github.com/sympower/msa-flex-adapter-frequency/actions/runs/5444643226/jobs/9903093331?pr=103) failing because the name became `refs/pull/103/merge`.

If I am reading what [the variables GitHub has](https://docs.github.com/en/actions/learn-github-actions/variables) correctly, then changing to this one should fix that and work for other cases as well. 