### PR TITLE
AF-263 Fix so release-for-testing also works when for Pull request

### DIFF
--- a/.github/workflows/release-for-testing.yml
+++ b/.github/workflows/release-for-testing.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set env
         run: |
           set -ue ;
-          tag=$(echo ${GITHUB_REF_NAME} | cut -c 1-20) ;
+          tag=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}} | cut -c 1-20) ;
           echo "VERSION=$(echo $tag)" >> $GITHUB_ENV ;
         shell: bash
 


### PR DESCRIPTION
Changing from `${GITHUB_REF#refs/heads/}` to `${GITHUB_REF_NAME}` did not work.
The name went from being `refs/pull/103/merge` to `103/merge` which is still an invalid name.

So changing instead to use `GITHUB_HEAD_REF` if it is set should result in always using the branch name.
``` markdown
The head ref or source branch of the pull request in a workflow run. 
This property is only set when the event that triggers a workflow run 
is either `pull_request` or `pull_request_target`. For example, `feature-branch-1`.
```
// https://docs.github.com/en/actions/learn-github-actions/variables

This means that `${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}` should result in the branch name no matter what the trigger is. 