### PR TITLE
AF-280 Support branch names with slash in release-for-testing

### DIFF
--- a/.github/workflows/release-for-testing.yml
+++ b/.github/workflows/release-for-testing.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set env
         run: |
           set -ue ;
-          tag=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}} | cut -c 1-20) ;
+          tag=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}} | cut -c 1-20 | tr / -) ;
           echo "VERSION=$(echo $tag)" >> $GITHUB_ENV ;
         shell: bash
 


### PR DESCRIPTION
Fixing for example https://github.com/sympower/msa-flex-adapter-frequency/pull/105

So that `renovate/avro` becomes `renovate-avro`. Since Docker tags are not supposed to have `/`. 

```
...
The tag must be valid ASCII and can contain lowercase and uppercase letters, digits, underscores, periods, and hyphens
...
```
// https://docs.docker.com/engine/reference/commandline/tag/