### PR TITLE
TECH-1131: updated steps to always upload builds results

### DIFF
--- a/.github/workflows/release-for-testing.yml
+++ b/.github/workflows/release-for-testing.yml
@@ -133,6 +133,7 @@ jobs:
           fi
 
       - name: Upload build results
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: results

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -310,6 +310,7 @@ jobs:
           fi
 
       - name: Upload build results
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: results


### PR DESCRIPTION
If a build fails because of a failing IT, the build results aren't uploaded. This PR ensures build results are always uploaded.