### PR TITLE
AF-588 Remove failing schema upload step from release-for-testing

### DIFF
--- a/.github/workflows/release-for-testing.yml
+++ b/.github/workflows/release-for-testing.yml
@@ -33,14 +33,6 @@ jobs:
         uses: sympower/sympower-composite-actions/build-and-upload-docker-image@2024.04.01.08.40-d465e36
         with:
           version: ${{ steps.format-version.outputs.version }}
-      - id: upload-schema
-        name: "Upload schema"
-        uses: sympower/sympower-composite-actions/upload-schema@2024.04.01.08.40-d465e36
-        with:
-          secrets: ${{ env.secrets }}
-          style-as-release: false
-          version: ${{ steps.format-version.outputs.version }}
-          gistID: "not-used"
       - id: upload-build-artifacts
         name: "Upload build artifacts"
         if: always()


### PR DESCRIPTION
Getting 400 trying to upload snapshot version.
Do not think we are using these schemas anywhere.
See example of the step failing here:
https://github.com/sympower/msa-portfolio-manager/actions/runs/8524626994/job/23349653982?pr=480