### PR TITLE
INFRA-2103 Update build-and-push docker image workflow

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -22,6 +22,16 @@ on:
         type: string
         description: "Path to the Dockerfile"
         required: true
+      platforms:
+        type: string
+        description: "Platforms to build for"
+        required: false
+        default: "linux/amd64,linux/arm64"
+      provenance:
+        type: boolean
+        description: "Enable provenance"
+        required: false
+        default: true
 
 jobs:
   build_and_push:
@@ -49,7 +59,8 @@ jobs:
           context: ${{ inputs.context_path }}
           file: ${{ inputs.dockerfile_path }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platforms }}
+          provenance: ${{ inputs.provenance }}
           tags: ${{ secrets.DOCKER_REGISTRY_HOST }}/${{ inputs.image_name }}:${{ inputs.image_tag }}
 
       - name: Docker image pushed successfully

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ the Docker build context resides, typically where your Dockerfile and related
 files are located.
 - **dockerfile_path**: The path to the Dockerfile. This should point to the
 Dockerfile in the build context directory.
+- **platforms**: The list of target platforms for build.
+- **provenance**: Controls whether provenance attestation for the build is required or not.
 
 ### Example of Use
 ```yaml


### PR DESCRIPTION
While building a new image for the Cognito custom sender Lambda function  
using this workflow it's been found that Lambda does not yet support  
multi-arch container images.  
That is, in order to reuse this GH workflow for the Lambda function  
image creation, an ability to change platforms to match the compute  
architecture and disable provenance should be added to the workflow.  
This change adds additional inputs to the workflow and sets the default  
values to match the current behavior.  