### PR TITLE
TECH-1230: Add upload-openapi-schema step to release-new-version

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -74,6 +74,13 @@ jobs:
           version: ${{ steps.format-version.outputs.version }}
           secrets: ${{ env.secrets }}
           gistID: ${{ inputs.gistID }}
+      - id: upload-openapi-schema
+        name: "Upload OpenAPI schema"
+        if: env.IS_DEFAULT_BRANCH == 'true'
+        uses: sympower/sympower-composite-actions/upload-openapi-schema@2024.07.31.12.26-dd8f9fa
+        with:
+          version: ${{ steps.format-version.outputs.version }}
+          secrets: ${{ env.secrets }}
       - id: upload-pacts
         name: "Upload pacts"
         if: env.IS_DEFAULT_BRANCH == 'true'


### PR DESCRIPTION
Now that [this](https://github.com/sympower/sympower-gradle-plugins/pull/380) got merged, we can add an extra step that publishes the openapi schemas (if any).

Note that although we can approve this pr already, we should only merge it after the latest `sympower-gradle-plugins` version has been rolled out to msas. Otherwise, the gh action step will attempt to execute a gradle task that has not yet been configured. 